### PR TITLE
test: mark GeekHunter ingestion as unsupported legacy

### DIFF
--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -23,9 +23,14 @@ It is not the production application.
 - The notebook was originally executed with Python `3.7.6`.
 - Install a Chrome browser and compatible ChromeDriver through the operating system, container image, or an automated driver manager before running the scraping cells.
 - The notebook reflects the original exploratory workflow and historical source assumptions; it is not exercised by CI.
-- Review the target site's current terms and selectors before running the scraper.
+- Do not run the historical GeekHunter scraper without prior written authorization.
+  [GeekHunter's current terms](https://www.geekhunter.com.br/pt/termos-de-uso) prohibit automated
+  scraping or crawler tools without that authorization.
+- The historical selectors and Selenium APIs are unvalidated and may no longer work.
 
 ## Boundary With Production Code
 
 - exploratory helpers in this directory are not imported by the application
 - production ingestion, normalization, enrichment, analytics, and API code lives under `src/`
+- the production GeekHunter parser is retained for provenance and fixture-based parsing only; live
+  GeekHunter retrieval is unsupported

--- a/src/job_market/infrastructure/ingestion/geekhunter.py
+++ b/src/job_market/infrastructure/ingestion/geekhunter.py
@@ -1,4 +1,4 @@
-"""Source-specific parser for the original GeekHunter notebook flow."""
+"""Unsupported legacy parser for the original GeekHunter notebook flow."""
 
 from __future__ import annotations
 
@@ -11,12 +11,19 @@ from job_market.shared.text import normalize_whitespace
 
 
 class GeekHunterHtmlAdapter:
-    """Convert scraped GeekHunter job-card HTML into raw source records."""
+    """Parse preserved GeekHunter HTML fixtures without retrieving live data.
+
+    The adapter exists to preserve Version 1 parsing provenance. It is not an
+    operational V2 connector: historical selectors are unvalidated and live
+    retrieval requires written source authorization before reimplementation.
+    """
 
     source_name = "geekhunter"
 
     def fetch(self) -> list[RawJobRecord]:
-        raise NotImplementedError("Live fetching remains in the exploratory notebook for now.")
+        raise NotImplementedError(
+            "Live GeekHunter ingestion is unsupported; use only authorized source integrations."
+        )
 
     def parse_job_card(self, job_html: str, *, source_url: str | None = None) -> RawJobRecord:
         soup = BeautifulSoup(job_html, "html.parser")

--- a/tests/unit/test_geekhunter_legacy_adapter.py
+++ b/tests/unit/test_geekhunter_legacy_adapter.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from datetime import UTC
+
+import pytest
+
+from job_market.infrastructure.ingestion.geekhunter import GeekHunterHtmlAdapter
+
+
+def test_legacy_adapter_does_not_fetch_live_geekhunter_data() -> None:
+    adapter = GeekHunterHtmlAdapter()
+
+    with pytest.raises(NotImplementedError, match="unsupported"):
+        adapter.fetch()
+
+
+def test_legacy_adapter_preserves_source_provenance_for_supplied_html() -> None:
+    adapter = GeekHunterHtmlAdapter()
+    html = '<article class="job"><a href="/vagas/backend-123">Backend Engineer</a></article>'
+
+    before_parse = adapter.parse_job_card(html).observed_at
+    record = adapter.parse_job_card(html, source_url="https://example.invalid/historical-fixture")
+
+    assert record.source_name == "geekhunter"
+    assert record.source_job_id == "/vagas/backend-123"
+    assert record.source_url == "https://example.invalid/historical-fixture"
+    assert record.payload == html
+    assert record.observed_at.tzinfo == UTC
+    assert record.observed_at >= before_parse


### PR DESCRIPTION
## Summary

- explicitly mark the GeekHunter adapter as unsupported legacy ingestion
- document its status in the notebook guidance
- add focused unit coverage for the legacy adapter

## Scope

Legacy adapter behavior, documentation, and tests.