### PR TITLE
feat: add market intelligence dashboard

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,1 +1,2 @@
-VITE_API_BASE_URL=http://localhost:8000
+VITE_API_BASE_URL=/api
+API_PROXY_TARGET=http://localhost:8000

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -28,12 +28,13 @@ Start the development server:
 npm run dev
 ```
 
-The frontend runs at `http://localhost:3000` by default. The API base URL defaults to
-`http://localhost:8000` and can be changed with `VITE_API_BASE_URL`.
+The frontend runs at `http://localhost:3000` by default. The API base URL defaults to `/api`,
+which the Vite development server proxies to `http://localhost:8000`. It can be changed with
+`VITE_API_BASE_URL`. If the local API uses a different origin, configure `API_PROXY_TARGET`.
 
-The backend does not yet configure CORS. Cross-origin API requests from the standalone frontend
-will be enabled in the later Docker Compose integration task. The foundation routes do not issue
-API requests.
+The local proxy lets the standalone dashboard use the API without broadening backend CORS.
+Production API routing and environment-scoped CORS will be finalized in the later Docker Compose
+integration task.
 
 ## Scripts
 
@@ -52,7 +53,7 @@ quality task.
 | Route | Current state |
 | --- | --- |
 | `/` | Product overview and developer access |
-| `/market` | Foundation placeholder for the market dashboard |
+| `/market` | API-backed market dashboard |
 | `/jobs` | Foundation placeholder for the job explorer |
 | `/match` | Foundation placeholder for candidate matching |
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,4 +1,4 @@
-const DEFAULT_API_BASE_URL = 'http://localhost:8000'
+const DEFAULT_API_BASE_URL = '/api'
 
 function normalizeBaseUrl(value: string): string {
   return value.replace(/\/+$/, '')

--- a/frontend/src/api/market.ts
+++ b/frontend/src/api/market.ts
@@ -1,0 +1,43 @@
+import { requestJson } from './client'
+
+export type JobSummary = {
+  job_id: number
+  title: string
+  source_name: string
+  work_mode: string
+  location_text: string | null
+  salary_text: string | null
+}
+
+export type MetricBucket = {
+  label: string
+  value: number
+}
+
+export type SkillCooccurrence = {
+  left_skill: string
+  right_skill: string
+  frequency: number
+}
+
+export function getJobs(signal?: AbortSignal) {
+  return requestJson<JobSummary[]>('/v1/jobs', { signal })
+}
+
+export function getTopSkills(signal?: AbortSignal) {
+  return requestJson<MetricBucket[]>('/v1/analytics/skills/top', { signal })
+}
+
+export function getTopTechnologies(signal?: AbortSignal) {
+  return requestJson<MetricBucket[]>(
+    '/v1/analytics/technologies/top',
+    { signal },
+  )
+}
+
+export function getSkillCooccurrence(signal?: AbortSignal) {
+  return requestJson<SkillCooccurrence[]>(
+    '/v1/analytics/skills/cooccurrence',
+    { signal },
+  )
+}

--- a/frontend/src/components/MetricBars.tsx
+++ b/frontend/src/components/MetricBars.tsx
@@ -1,0 +1,29 @@
+import type { MetricBucket } from '../api/market'
+
+type MetricBarsProps = {
+  items: MetricBucket[]
+  ariaLabel: string
+}
+
+export function MetricBars({ items, ariaLabel }: MetricBarsProps) {
+  const maximum = Math.max(...items.map((item) => item.value), 1)
+
+  return (
+    <ol className="metric-bars" aria-label={ariaLabel}>
+      {items.map((item) => (
+        <li key={item.label}>
+          <div className="metric-label">
+            <span>{item.label}</span>
+            <strong>{item.value}</strong>
+          </div>
+          <div className="metric-track" aria-hidden="true">
+            <span
+              className="metric-fill"
+              style={{ width: `${(item.value / maximum) * 100}%` }}
+            />
+          </div>
+        </li>
+      ))}
+    </ol>
+  )
+}

--- a/frontend/src/components/PanelState.tsx
+++ b/frontend/src/components/PanelState.tsx
@@ -1,0 +1,48 @@
+import type { ReactNode } from 'react'
+
+import type { ResourceState } from '../hooks/useApiResource'
+import { EmptyState, ErrorState, LoadingState } from './AsyncState'
+
+type PanelStateProps<T> = {
+  state: ResourceState<T>
+  isEmpty: (data: T) => boolean
+  emptyTitle: string
+  emptyMessage: string
+  errorTitle: string
+  onRetry: () => void
+  children: (data: T) => ReactNode
+}
+
+export function PanelState<T>({
+  state,
+  isEmpty,
+  emptyTitle,
+  emptyMessage,
+  errorTitle,
+  onRetry,
+  children,
+}: PanelStateProps<T>) {
+  if (state.status === 'loading') {
+    return <LoadingState message="Retrieving data from the platform API." />
+  }
+
+  if (state.status === 'error') {
+    return (
+      <ErrorState
+        title={errorTitle}
+        message={state.message}
+        action={
+          <button className="state-action" type="button" onClick={onRetry}>
+            Try again
+          </button>
+        }
+      />
+    )
+  }
+
+  if (isEmpty(state.data)) {
+    return <EmptyState title={emptyTitle} message={emptyMessage} />
+  }
+
+  return children(state.data)
+}

--- a/frontend/src/hooks/useApiResource.ts
+++ b/frontend/src/hooks/useApiResource.ts
@@ -26,10 +26,15 @@ export function useApiResource<T>(
     setState({ status: 'loading' })
     load(controller.signal)
       .then((data) => {
-        setState({ status: 'success', data })
+        if (!controller.signal.aborted) {
+          setState({ status: 'success', data })
+        }
       })
       .catch((error: unknown) => {
-        if (error instanceof DOMException && error.name === 'AbortError') {
+        if (
+          controller.signal.aborted ||
+          (error instanceof DOMException && error.name === 'AbortError')
+        ) {
           return
         }
 

--- a/frontend/src/hooks/useApiResource.ts
+++ b/frontend/src/hooks/useApiResource.ts
@@ -1,0 +1,49 @@
+import { useCallback, useEffect, useState } from 'react'
+
+export type ResourceState<T> =
+  | { status: 'loading' }
+  | { status: 'success'; data: T }
+  | { status: 'error'; message: string }
+
+type ResourceResult<T> = {
+  state: ResourceState<T>
+  retry: () => void
+}
+
+export function useApiResource<T>(
+  load: (signal: AbortSignal) => Promise<T>,
+): ResourceResult<T> {
+  const [attempt, setAttempt] = useState(0)
+  const [state, setState] = useState<ResourceState<T>>({ status: 'loading' })
+
+  const retry = useCallback(() => {
+    setAttempt((current) => current + 1)
+  }, [])
+
+  useEffect(() => {
+    const controller = new AbortController()
+
+    setState({ status: 'loading' })
+    load(controller.signal)
+      .then((data) => {
+        setState({ status: 'success', data })
+      })
+      .catch((error: unknown) => {
+        if (error instanceof DOMException && error.name === 'AbortError') {
+          return
+        }
+
+        setState({
+          status: 'error',
+          message:
+            error instanceof Error
+              ? error.message
+              : 'The request could not be completed.',
+        })
+      })
+
+    return () => controller.abort()
+  }, [attempt, load])
+
+  return { state, retry }
+}

--- a/frontend/src/pages/MarketDashboardPage.tsx
+++ b/frontend/src/pages/MarketDashboardPage.tsx
@@ -1,12 +1,213 @@
-import { FeaturePlaceholder } from '../components/FeaturePlaceholder'
+import {
+  getJobs,
+  getSkillCooccurrence,
+  getTopSkills,
+  getTopTechnologies,
+  type JobSummary,
+} from '../api/market'
+import { MetricBars } from '../components/MetricBars'
+import { PanelState } from '../components/PanelState'
+import { useApiResource } from '../hooks/useApiResource'
+
+const displayedMetricLimit = 8
+const workModeOrder = ['remote', 'hybrid', 'onsite', 'unknown']
+
+function formatLabel(value: string) {
+  return value
+    .replaceAll('_', ' ')
+    .replace(/\b\w/g, (character) => character.toUpperCase())
+}
+
+function countWorkModes(jobs: JobSummary[]) {
+  const counts = new Map<string, number>()
+
+  for (const job of jobs) {
+    const workMode = job.work_mode || 'unknown'
+    counts.set(workMode, (counts.get(workMode) ?? 0) + 1)
+  }
+
+  return [...counts.entries()].toSorted(([left], [right]) => {
+    const leftIndex = workModeOrder.indexOf(left)
+    const rightIndex = workModeOrder.indexOf(right)
+    const normalizedLeft = leftIndex === -1 ? workModeOrder.length : leftIndex
+    const normalizedRight = rightIndex === -1 ? workModeOrder.length : rightIndex
+    return normalizedLeft - normalizedRight || left.localeCompare(right)
+  })
+}
 
 export function MarketDashboardPage() {
+  const jobs = useApiResource(getJobs)
+  const skills = useApiResource(getTopSkills)
+  const technologies = useApiResource(getTopTechnologies)
+  const cooccurrence = useApiResource(getSkillCooccurrence)
+
   return (
-    <FeaturePlaceholder
-      eyebrow="Market dashboard"
-      title="Turn stored job data into a readable signal."
-      description="Explore supported skill, technology, co-occurrence, and work-mode metrics without overstating dataset coverage."
-      nextStep="The next feature pull request will connect this route to the existing analytics and jobs endpoints with loading, empty, partial, and error states."
-    />
+    <div className="dashboard page-stack">
+      <header className="page-header dashboard-header">
+        <div>
+          <p className="eyebrow">Market dashboard</p>
+          <h1>Signals from the jobs stored here.</h1>
+          <p className="page-lead">
+            Explore current skill, technology, co-occurrence, and work-mode
+            counts returned by the platform API.
+          </p>
+        </div>
+        <aside className="coverage-note" aria-label="Dataset coverage">
+          <span aria-hidden="true">i</span>
+          <p>
+            Counts describe this instance only. The API does not yet provide
+            coverage, freshness, or live-ingestion guarantees.
+          </p>
+        </aside>
+      </header>
+
+      <section className="dashboard-summary" aria-labelledby="summary-heading">
+        <div className="panel-heading">
+          <div>
+            <p className="panel-kicker">Snapshot</p>
+            <h2 id="summary-heading">Stored market records</h2>
+          </div>
+          <p>Job count and API-provided work modes.</p>
+        </div>
+
+        <PanelState
+          state={jobs.state}
+          isEmpty={(data) => data.length === 0}
+          emptyTitle="No jobs are stored yet"
+          emptyMessage="Market totals and work-mode counts will appear after manually authored or authorized records are added."
+          errorTitle="Job summary is unavailable"
+          onRetry={jobs.retry}
+        >
+          {(data) => (
+            <div className="summary-grid">
+              <article className="total-card">
+                <p>Jobs in this instance</p>
+                <strong>{data.length}</strong>
+                <span>Not live market coverage</span>
+              </article>
+
+              <div className="work-mode-grid" aria-label="Work-mode distribution">
+                {countWorkModes(data).map(([label, value]) => (
+                  <article className="summary-card" key={label}>
+                    <p>{formatLabel(label)}</p>
+                    <strong>{value}</strong>
+                    <span>
+                      {Math.round((value / data.length) * 100)}% of stored jobs
+                    </span>
+                  </article>
+                ))}
+              </div>
+            </div>
+          )}
+        </PanelState>
+      </section>
+
+      <div className="dashboard-grid">
+        <section className="dashboard-panel" aria-labelledby="skills-heading">
+          <div className="panel-heading">
+            <div>
+              <p className="panel-kicker">Demand signals</p>
+              <h2 id="skills-heading">Top skills</h2>
+            </div>
+            <p>Mentions across enriched jobs.</p>
+          </div>
+          <PanelState
+            state={skills.state}
+            isEmpty={(data) => data.length === 0}
+            emptyTitle="No skill metrics yet"
+            emptyMessage="Skill counts appear when stored jobs have enrichment results."
+            errorTitle="Skill metrics are unavailable"
+            onRetry={skills.retry}
+          >
+            {(data) => (
+              <MetricBars
+                items={data.slice(0, displayedMetricLimit)}
+                ariaLabel="Top skills by number of enriched jobs"
+              />
+            )}
+          </PanelState>
+        </section>
+
+        <section
+          className="dashboard-panel"
+          aria-labelledby="technologies-heading"
+        >
+          <div className="panel-heading">
+            <div>
+              <p className="panel-kicker">Tooling signals</p>
+              <h2 id="technologies-heading">Top technologies</h2>
+            </div>
+            <p>Detected tools and platforms.</p>
+          </div>
+          <PanelState
+            state={technologies.state}
+            isEmpty={(data) => data.length === 0}
+            emptyTitle="No technology metrics yet"
+            emptyMessage="Technology counts appear when stored jobs have enrichment results."
+            errorTitle="Technology metrics are unavailable"
+            onRetry={technologies.retry}
+          >
+            {(data) => (
+              <MetricBars
+                items={data.slice(0, displayedMetricLimit)}
+                ariaLabel="Top technologies by number of enriched jobs"
+              />
+            )}
+          </PanelState>
+        </section>
+      </div>
+
+      <section
+        className="dashboard-panel cooccurrence-panel"
+        aria-labelledby="cooccurrence-heading"
+      >
+        <div className="panel-heading">
+          <div>
+            <p className="panel-kicker">Relationships</p>
+            <h2 id="cooccurrence-heading">Skills that appear together</h2>
+          </div>
+          <p>
+            Distinct skill pairs found in the same enriched job. Frequency is
+            shown as text and is not represented by colour alone.
+          </p>
+        </div>
+        <PanelState
+          state={cooccurrence.state}
+          isEmpty={(data) => data.length === 0}
+          emptyTitle="No skill relationships yet"
+          emptyMessage="At least one enriched job with two detected skills is required."
+          errorTitle="Skill relationships are unavailable"
+          onRetry={cooccurrence.retry}
+        >
+          {(data) => (
+            <div className="table-scroll">
+              <table className="cooccurrence-table">
+                <caption className="visually-hidden">
+                  Most frequent skill pairs
+                </caption>
+                <thead>
+                  <tr>
+                    <th scope="col">Skill pair</th>
+                    <th scope="col">Jobs together</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.slice(0, displayedMetricLimit).map((item) => (
+                    <tr key={`${item.left_skill}:${item.right_skill}`}>
+                      <td>
+                        <span>{item.left_skill}</span>
+                        <span aria-hidden="true">+</span>
+                        <span>{item.right_skill}</span>
+                      </td>
+                      <td>{item.frequency}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </PanelState>
+      </section>
+    </div>
   )
 }

--- a/frontend/src/pages/MarketDashboardPage.tsx
+++ b/frontend/src/pages/MarketDashboardPage.tsx
@@ -22,7 +22,9 @@ function countWorkModes(jobs: JobSummary[]) {
   const counts = new Map<string, number>()
 
   for (const job of jobs) {
-    const workMode = job.work_mode || 'unknown'
+    const workMode = workModeOrder.includes(job.work_mode)
+      ? job.work_mode
+      : 'unknown'
     counts.set(workMode, (counts.get(workMode) ?? 0) + 1)
   }
 

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -607,6 +607,280 @@ p {
   background: #f8dfdd;
 }
 
+.state-action {
+  margin-top: 14px;
+  padding: 8px 13px;
+  border: 1px solid #c99894;
+  border-radius: 7px;
+  color: #762d29;
+  background: white;
+  font-size: 0.8rem;
+  font-weight: 750;
+  cursor: pointer;
+}
+
+.state-action:hover {
+  background: #fff1f0;
+}
+
+.dashboard-header {
+  display: grid;
+  max-width: none;
+  grid-template-columns: minmax(0, 1.45fr) minmax(280px, 0.55fr);
+  align-items: end;
+  gap: clamp(32px, 7vw, 86px);
+}
+
+.coverage-note {
+  display: flex;
+  padding: 18px;
+  border: 1px solid #ded4b8;
+  border-radius: 11px;
+  background: #faf4e5;
+  gap: 12px;
+}
+
+.coverage-note > span {
+  display: grid;
+  width: 24px;
+  height: 24px;
+  flex: 0 0 auto;
+  place-items: center;
+  border: 1px solid #8d7950;
+  border-radius: 50%;
+  color: #594c2e;
+  font-family: Georgia, serif;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.coverage-note p {
+  margin: 0;
+  color: #594c2e;
+  font-size: 0.79rem;
+  line-height: 1.55;
+}
+
+.dashboard-summary,
+.dashboard-panel {
+  padding: clamp(24px, 4vw, 36px);
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  background: rgb(255 254 250 / 82%);
+}
+
+.dashboard-summary {
+  margin-bottom: 20px;
+}
+
+.panel-heading {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  margin-bottom: 28px;
+  gap: 28px;
+}
+
+.panel-heading h2 {
+  margin: 0;
+  font-size: clamp(1.4rem, 2.5vw, 1.9rem);
+}
+
+.panel-heading > p {
+  max-width: 420px;
+  margin: 0;
+  font-size: 0.82rem;
+  text-align: right;
+}
+
+.panel-kicker {
+  margin: 0 0 7px;
+  color: var(--teal-dark);
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: 0.75fr 2.25fr;
+  gap: 14px;
+}
+
+.work-mode-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(145px, 1fr));
+  gap: 14px;
+}
+
+.total-card,
+.summary-card {
+  min-height: 154px;
+  padding: 22px;
+  border-radius: 12px;
+}
+
+.total-card {
+  color: white;
+  background: var(--navy);
+}
+
+.summary-card {
+  border: 1px solid var(--line);
+  background: white;
+}
+
+.total-card p,
+.summary-card p {
+  margin: 0 0 22px;
+  color: inherit;
+  font-size: 0.76rem;
+  font-weight: 700;
+}
+
+.summary-card p {
+  color: var(--muted);
+}
+
+.total-card strong,
+.summary-card strong {
+  display: block;
+  margin-bottom: 8px;
+  font-size: 2.35rem;
+  line-height: 1;
+}
+
+.summary-card strong {
+  color: var(--ink);
+}
+
+.total-card span,
+.summary-card span {
+  color: #afc1ca;
+  font-size: 0.7rem;
+}
+
+.summary-card span {
+  color: var(--muted);
+}
+
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  margin-bottom: 20px;
+  gap: 20px;
+}
+
+.metric-bars {
+  display: grid;
+  margin: 0;
+  padding: 0;
+  gap: 17px;
+  list-style: none;
+}
+
+.metric-label {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 7px;
+  gap: 16px;
+  color: var(--ink);
+  font-size: 0.79rem;
+}
+
+.metric-label span {
+  text-transform: capitalize;
+}
+
+.metric-label strong {
+  font-variant-numeric: tabular-nums;
+}
+
+.metric-track {
+  overflow: hidden;
+  height: 7px;
+  border-radius: 999px;
+  background: #e7ece9;
+}
+
+.metric-fill {
+  display: block;
+  min-width: 3px;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--teal);
+}
+
+.cooccurrence-panel .panel-heading {
+  align-items: start;
+}
+
+.table-scroll {
+  overflow-x: auto;
+}
+
+.cooccurrence-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.cooccurrence-table th,
+.cooccurrence-table td {
+  padding: 15px 12px;
+  border-bottom: 1px solid var(--line);
+  text-align: left;
+}
+
+.cooccurrence-table th {
+  color: var(--muted);
+  font-size: 0.68rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.cooccurrence-table td {
+  color: var(--ink);
+  font-size: 0.82rem;
+}
+
+.cooccurrence-table th:last-child,
+.cooccurrence-table td:last-child {
+  width: 145px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.cooccurrence-table td:first-child {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 9px;
+}
+
+.cooccurrence-table td:first-child span:not([aria-hidden]) {
+  padding: 5px 9px;
+  border-radius: 999px;
+  background: var(--teal-soft);
+  font-weight: 700;
+}
+
+.cooccurrence-table td:first-child span[aria-hidden] {
+  color: var(--muted);
+}
+
+.visually-hidden {
+  position: absolute;
+  overflow: hidden;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  border: 0;
+  margin: -1px;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
 .not-found {
   max-width: 720px;
   padding-block: 80px;
@@ -679,7 +953,10 @@ p {
 
   .hero,
   .developer-strip,
-  .placeholder-card {
+  .placeholder-card,
+  .dashboard-header,
+  .summary-grid,
+  .dashboard-grid {
     grid-template-columns: 1fr;
   }
 
@@ -711,6 +988,16 @@ p {
 
   .placeholder-grid {
     min-height: 220px;
+  }
+
+  .panel-heading {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .panel-heading > p {
+    text-align: left;
   }
 }
 

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
-    "target": "ES2022",
+    "target": "ES2023",
     "useDefineForClassFields": true,
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "types": ["vite/client"],
     "allowJs": false,
     "skipLibCheck": true,

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,14 +1,27 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 
-export default defineConfig({
-  plugins: [react()],
-  server: {
-    host: '0.0.0.0',
-    port: 3000,
-  },
-  preview: {
-    host: '0.0.0.0',
-    port: 3000,
-  },
+export default defineConfig(({ mode }) => {
+  const environment = loadEnv(mode, process.cwd(), '')
+  const apiProxyTarget =
+    environment.API_PROXY_TARGET || 'http://localhost:8000'
+
+  return {
+    plugins: [react()],
+    server: {
+      host: '0.0.0.0',
+      port: 3000,
+      proxy: {
+        '/api': {
+          target: apiProxyTarget,
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/api/, ''),
+        },
+      },
+    },
+    preview: {
+      host: '0.0.0.0',
+      port: 3000,
+    },
+  }
 })


### PR DESCRIPTION
## Purpose

Turn the existing jobs and analytics API responses into a clear market dashboard without overstating dataset coverage or adding unsupported metrics.

## Changes

- display total jobs stored in the current instance
- derive work-mode counts from API-provided job values
- visualize the top eight skills and technologies with accessible numeric bars
- display top skill co-occurrence pairs in a semantic table
- load jobs, skills, technologies, and co-occurrence independently
- add reusable loading, empty, error, and retry handling for dashboard panels
- label metrics as instance-local, with no live coverage or freshness claim
- add a configurable same-origin Vite development proxy for the API
- document the API base URL and proxy target configuration

## Validation

- `npm ci`
- `npm audit` — 0 vulnerabilities
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- dashboard route and all four proxied API paths returned HTTP 200 using synthetic records
- staged diff and whitespace checks passed
- sensitive-file, likely-secret, credential, personal-path, and email checks passed

## Security and privacy

- no job records, candidate data, or screenshots are committed
- local validation used synthetic records only
- the environment template contains localhost values only
- failed panels expose a generic status message rather than response bodies
- the UI visibly states that metrics are not live or complete market coverage

## Known limitations

- total jobs and work-mode counts are derived client-side from the unpaginated jobs endpoint
- the API does not expose freshness, coverage, seniority distribution, location distribution, or time-series metrics
- frontend component tests remain scheduled for the dedicated quality pull request
- the backend must be running for populated dashboard panels
- production API routing and CORS remain part of the Compose integration task
- this pull request must be merged before job explorer work begins