### PR TITLE
feat: expose job explorer API fields

### DIFF
--- a/docs/07-api-examples.md
+++ b/docs/07-api-examples.md
@@ -39,11 +39,25 @@ curl -X POST http://localhost:8000/v1/jobs:upload \
 curl http://localhost:8000/v1/jobs
 ```
 
+The list remains unbounded when no query parameters are provided for compatibility. Public
+interfaces should request a bounded result set and may filter by source or work mode:
+
+```bash
+curl "http://localhost:8000/v1/jobs?limit=20&offset=0&source_name=manual_upload&work_mode=remote"
+```
+
+`limit` accepts 1 through 100. `offset` must be zero or greater. Supported work-mode values are
+`remote`, `hybrid`, `onsite`, and `unknown`.
+
 ## Get A Job
 
 ```bash
 curl http://localhost:8000/v1/jobs/1
 ```
+
+Job detail responses add the stored description, company, source URL, publication time, observation
+time, employment type, structured location, seniority hint, and enrichment when those values are
+available. Missing source fields remain `null`; the API does not infer them.
 
 ## Top Skills
 

--- a/src/job_market/application/ports.py
+++ b/src/job_market/application/ports.py
@@ -13,17 +13,25 @@ from job_market.domain.enrichment.models import (
     SkillEvidence,
     TechnologyEvidence,
 )
-from job_market.domain.jobs.models import JobPosting, RawJobRecord
+from job_market.domain.jobs.models import JobPosting, RawJobRecord, WorkMode
 from job_market.domain.matching.models import MatchResult
 
 
 class RawJobRepository(Protocol):
     def add(self, record: RawJobRecord) -> RawJobRecord: ...
+    def get_by_id(self, record_id: int) -> RawJobRecord | None: ...
 
 
 class JobRepository(Protocol):
     def add(self, job: JobPosting) -> JobPosting: ...
-    def list_all(self) -> Sequence[JobPosting]: ...
+    def list_all(
+        self,
+        *,
+        limit: int | None = None,
+        offset: int = 0,
+        source_name: str | None = None,
+        work_mode: WorkMode | None = None,
+    ) -> Sequence[JobPosting]: ...
     def get_by_id(self, job_id: int) -> JobPosting | None: ...
 
 

--- a/src/job_market/infrastructure/repositories/memory.py
+++ b/src/job_market/infrastructure/repositories/memory.py
@@ -6,7 +6,7 @@ from collections import Counter
 
 from job_market.domain.analytics.models import MetricBucket, SkillCooccurrence
 from job_market.domain.enrichment.models import JobEnrichment
-from job_market.domain.jobs.models import JobPosting, RawJobRecord
+from job_market.domain.jobs.models import JobPosting, RawJobRecord, WorkMode
 from job_market.domain.matching.models import MatchResult
 
 
@@ -27,6 +27,9 @@ class InMemoryRawJobRepository:
         self._next_id += 1
         self._records.append(stored)
         return stored
+
+    def get_by_id(self, record_id: int) -> RawJobRecord | None:
+        return next((record for record in self._records if record.record_id == record_id), None)
 
 
 class InMemoryJobRepository:
@@ -54,8 +57,24 @@ class InMemoryJobRepository:
         self._jobs.append(stored)
         return stored
 
-    def list_all(self) -> list[JobPosting]:
-        return list(self._jobs)
+    def list_all(
+        self,
+        *,
+        limit: int | None = None,
+        offset: int = 0,
+        source_name: str | None = None,
+        work_mode: WorkMode | None = None,
+    ) -> list[JobPosting]:
+        jobs = self._jobs
+        if source_name is not None:
+            jobs = [job for job in jobs if job.source_name == source_name]
+        if work_mode is not None:
+            jobs = [job for job in jobs if job.work_mode == work_mode]
+
+        bounded_jobs = jobs[offset:]
+        if limit is not None:
+            bounded_jobs = bounded_jobs[:limit]
+        return list(bounded_jobs)
 
     def get_by_id(self, job_id: int) -> JobPosting | None:
         return next((job for job in self._jobs if job.job_id == job_id), None)

--- a/src/job_market/infrastructure/repositories/sqlalchemy.py
+++ b/src/job_market/infrastructure/repositories/sqlalchemy.py
@@ -56,6 +56,20 @@ class SqlAlchemyRawJobRepository:
                 observed_at=model.observed_at,
             )
 
+    def get_by_id(self, record_id: int) -> RawJobRecord | None:
+        with self._session_factory() as session:
+            model = session.get(RawJobRecordModel, record_id)
+            if model is None:
+                return None
+            return RawJobRecord(
+                record_id=model.id,
+                source_name=model.source_name,
+                source_job_id=model.source_job_id,
+                source_url=model.source_url,
+                payload=model.payload,
+                observed_at=model.observed_at,
+            )
+
 
 class SqlAlchemyJobRepository:
     def __init__(self, session_factory: SessionFactory) -> None:
@@ -88,9 +102,24 @@ class SqlAlchemyJobRepository:
             session.refresh(model)
             return _to_job_posting(model)
 
-    def list_all(self) -> list[JobPosting]:
+    def list_all(
+        self,
+        *,
+        limit: int | None = None,
+        offset: int = 0,
+        source_name: str | None = None,
+        work_mode: WorkMode | None = None,
+    ) -> list[JobPosting]:
         with self._session_factory() as session:
-            models = session.query(JobModel).order_by(JobModel.id.asc()).all()
+            query = session.query(JobModel)
+            if source_name is not None:
+                query = query.filter(JobModel.source_name == source_name)
+            if work_mode is not None:
+                query = query.filter(JobModel.work_mode == work_mode.value)
+            query = query.order_by(JobModel.id.asc()).offset(offset)
+            if limit is not None:
+                query = query.limit(limit)
+            models = query.all()
             return [_to_job_posting(model) for model in models]
 
     def get_by_id(self, job_id: int) -> JobPosting | None:

--- a/src/job_market/interfaces/api/dependencies.py
+++ b/src/job_market/interfaces/api/dependencies.py
@@ -48,6 +48,7 @@ from job_market.infrastructure.repositories.memory import (
 from job_market.interfaces.schemas.candidates import CandidateProfileRequest
 from job_market.interfaces.schemas.jobs import (
     JobEnrichmentResponse,
+    JobLocationResponse,
     JobResponse,
     JobWithEnrichmentResponse,
     ManualJobUploadRequest,
@@ -99,10 +100,26 @@ class ServiceRegistry:
         enrichment = self.enrichment_service.enrich(job)
         if job.job_id is None:
             raise InvalidStateError("The stored job did not receive an identifier.")
-        return build_job_with_enrichment_response(job, enrichment)
+        return build_job_with_enrichment_response(
+            job,
+            enrichment,
+            observed_at=self.get_observed_at(job),
+        )
 
-    def list_jobs(self) -> list[JobResponse]:
-        jobs = self.job_repository.list_all()
+    def list_jobs(
+        self,
+        *,
+        limit: int | None = None,
+        offset: int = 0,
+        source_name: str | None = None,
+        work_mode: WorkMode | None = None,
+    ) -> list[JobResponse]:
+        jobs = self.job_repository.list_all(
+            limit=limit,
+            offset=offset,
+            source_name=source_name,
+            work_mode=work_mode,
+        )
         return [build_job_response(job) for job in jobs]
 
     def get_job(self, job_id: int) -> JobWithEnrichmentResponse:
@@ -110,7 +127,17 @@ class ServiceRegistry:
         if job is None:
             raise ResourceNotFoundError(f"Job {job_id} was not found.")
         enrichment = self.enrichment_repository.get_by_job_id(job_id)
-        return build_job_with_enrichment_response(job, enrichment)
+        return build_job_with_enrichment_response(
+            job,
+            enrichment,
+            observed_at=self.get_observed_at(job),
+        )
+
+    def get_observed_at(self, job: JobPosting) -> datetime | None:
+        if job.raw_record_id is None:
+            return None
+        raw_record = self.raw_job_repository.get_by_id(job.raw_record_id)
+        return raw_record.observed_at if raw_record else None
 
     def match_candidate(self, request: CandidateProfileRequest) -> list[DomainMatchResult]:
         candidate = CandidateProfile(
@@ -137,6 +164,10 @@ def build_job_response(job: JobPosting) -> JobResponse:
         work_mode=job.work_mode.value,
         location_text=job.location.raw_text,
         salary_text=job.compensation.raw_text,
+        company_name=job.company_name,
+        source_url=job.source_url,
+        posted_at=job.posted_at,
+        employment_type=job.employment_type.value,
     )
 
 
@@ -176,9 +207,20 @@ def build_job_enrichment_response(enrichment: JobEnrichment | None) -> JobEnrich
 def build_job_with_enrichment_response(
     job: JobPosting,
     enrichment: JobEnrichment | None,
+    *,
+    observed_at: datetime | None,
 ) -> JobWithEnrichmentResponse:
     return JobWithEnrichmentResponse(
         **build_job_response(job).model_dump(),
+        description=job.description,
+        location=JobLocationResponse(
+            country=job.location.country,
+            region=job.location.region,
+            city=job.location.city,
+            raw_text=job.location.raw_text,
+        ),
+        seniority_hint=job.seniority_hint.value,
+        observed_at=observed_at,
         enrichment=build_job_enrichment_response(enrichment),
     )
 

--- a/src/job_market/interfaces/api/routes.py
+++ b/src/job_market/interfaces/api/routes.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Request, status
+from fastapi import APIRouter, Depends, Query, Request, status
 
 from job_market.domain.analytics.models import MetricBucket, SkillCooccurrence
+from job_market.domain.jobs.models import WorkMode
 from job_market.interfaces.api.dependencies import ServiceRegistry, get_registry, get_version
 from job_market.interfaces.schemas.analytics import (
     MetricBucketResponse,
@@ -74,8 +75,19 @@ def upload_job(
 
 
 @router.get("/v1/jobs", response_model=list[JobResponse], tags=["jobs"])
-def list_jobs(registry: RegistryDependency) -> list[JobResponse]:
-    return registry.list_jobs()
+def list_jobs(
+    registry: RegistryDependency,
+    limit: Annotated[int | None, Query(ge=1, le=100)] = None,
+    offset: Annotated[int, Query(ge=0)] = 0,
+    source_name: Annotated[str | None, Query(min_length=1, max_length=100)] = None,
+    work_mode: WorkMode | None = None,
+) -> list[JobResponse]:
+    return registry.list_jobs(
+        limit=limit,
+        offset=offset,
+        source_name=source_name,
+        work_mode=work_mode,
+    )
 
 
 @router.get("/v1/jobs/{job_id}", response_model=JobWithEnrichmentResponse, tags=["jobs"])

--- a/src/job_market/interfaces/schemas/jobs.py
+++ b/src/job_market/interfaces/schemas/jobs.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+
 from pydantic import BaseModel, Field
 
 from job_market.domain.jobs.models import WorkMode
@@ -31,6 +33,17 @@ class JobResponse(BaseModel):
     work_mode: str
     location_text: str | None = None
     salary_text: str | None = None
+    company_name: str | None = None
+    source_url: str | None = None
+    posted_at: datetime | None = None
+    employment_type: str
+
+
+class JobLocationResponse(BaseModel):
+    country: str | None = None
+    region: str | None = None
+    city: str | None = None
+    raw_text: str | None = None
 
 
 class JobEnrichmentResponse(BaseModel):
@@ -46,4 +59,8 @@ class JobEnrichmentResponse(BaseModel):
 
 
 class JobWithEnrichmentResponse(JobResponse):
+    description: str
+    location: JobLocationResponse
+    seniority_hint: str
+    observed_at: datetime | None = None
     enrichment: JobEnrichmentResponse | None = None

--- a/tests/api/test_api_routes.py
+++ b/tests/api/test_api_routes.py
@@ -46,6 +46,11 @@ def test_upload_job_and_query_enrichment(client: TestClient) -> None:
     assert upload_response.status_code == 201
     body = upload_response.json()
     assert body["title"] == "Senior Backend Engineer"
+    assert body["company_name"] is None
+    assert body["description"].startswith("We need Python")
+    assert body["employment_type"] == "unknown"
+    assert body["location"]["raw_text"] == "Remote - Brazil"
+    assert body["observed_at"] is not None
     assert body["enrichment"]["role_family"] == "backend_engineering"
     assert "python" in body["enrichment"]["skills"]
     assert body["enrichment"]["summary"] is not None
@@ -53,6 +58,84 @@ def test_upload_job_and_query_enrichment(client: TestClient) -> None:
     job_response = client.get(f"/v1/jobs/{body['job_id']}")
     assert job_response.status_code == 200
     assert job_response.json()["job_id"] == body["job_id"]
+
+
+def test_list_jobs_supports_bounded_queries_and_public_fields(client: TestClient) -> None:
+    jobs = [
+        {
+            "title": "Synthetic Remote Engineer",
+            "description": "Python and PostgreSQL.",
+            "source_name": "manual_upload",
+            "source_url": "https://example.invalid/jobs/remote-engineer",
+            "company_name": "Example Systems",
+            "work_mode": "remote",
+        },
+        {
+            "title": "Synthetic Onsite Engineer",
+            "description": "Java and AWS.",
+            "source_name": "curated_fixture",
+            "work_mode": "onsite",
+        },
+        {
+            "title": "Synthetic Platform Engineer",
+            "description": "Go and Docker.",
+            "source_name": "manual_upload",
+            "work_mode": "hybrid",
+        },
+    ]
+    for job in jobs:
+        response = client.post("/v1/jobs:upload", json=job)
+        assert response.status_code == 201
+
+    response = client.get(
+        "/v1/jobs",
+        params={
+            "source_name": "manual_upload",
+            "limit": 1,
+            "offset": 1,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == [
+        {
+            "job_id": 3,
+            "title": "Synthetic Platform Engineer",
+            "source_name": "manual_upload",
+            "work_mode": "hybrid",
+            "location_text": None,
+            "salary_text": None,
+            "company_name": None,
+            "source_url": None,
+            "posted_at": None,
+            "employment_type": "unknown",
+        }
+    ]
+
+    filtered_response = client.get("/v1/jobs", params={"work_mode": "onsite"})
+    assert filtered_response.status_code == 200
+    assert [job["title"] for job in filtered_response.json()] == ["Synthetic Onsite Engineer"]
+
+
+@pytest.mark.parametrize(
+    ("params", "field"),
+    [
+        ({"limit": 0}, "limit"),
+        ({"limit": 101}, "limit"),
+        ({"offset": -1}, "offset"),
+        ({"work_mode": "flexible"}, "work_mode"),
+    ],
+)
+def test_list_jobs_rejects_invalid_query_values(
+    client: TestClient,
+    params: dict[str, int | str],
+    field: str,
+) -> None:
+    response = client.get("/v1/jobs", params=params)
+
+    assert response.status_code == 422
+    assert response.json()["error"] == "validation_error"
+    assert any(error["loc"][-1] == field for error in response.json()["details"])
 
 
 def test_candidate_matches_endpoint(client: TestClient) -> None:

--- a/tests/api/test_api_routes.py
+++ b/tests/api/test_api_routes.py
@@ -49,6 +49,7 @@ def test_upload_job_and_query_enrichment(client: TestClient) -> None:
     assert body["company_name"] is None
     assert body["description"].startswith("We need Python")
     assert body["employment_type"] == "unknown"
+    assert body["seniority_hint"] == "unknown"
     assert body["location"]["raw_text"] == "Remote - Brazil"
     assert body["observed_at"] is not None
     assert body["enrichment"]["role_family"] == "backend_engineering"


### PR DESCRIPTION
## Purpose

Provide the smallest additive backend contract required for a credible job explorer before implementing its browser interface.

## Changes

- add optional `limit`, `offset`, `source_name`, and `work_mode` queries to `GET /v1/jobs`
- preserve unbounded list behavior when query parameters are omitted
- apply bounds and filters in both in-memory and SQLAlchemy repositories
- expose stored company, source URL, publication time, and employment type in job list responses
- expose description, structured location, seniority hint, observation time, and enrichment in job detail/upload responses
- add raw-record lookup for observation provenance without exposing raw payloads
- document bounded list queries and additive detail fields
- add synthetic API coverage for public fields, filters, bounds, provenance, and validation errors

## Validation

- `ruff check .`
- `ruff format --check .`
- `mypy`
- `pytest` — 18 passed
- `python -m compileall src apps tests alembic`
- staged diff and whitespace checks passed
- sensitive-file, likely-secret, credential, personal-path, and email checks passed

## Compatibility

Existing endpoint paths and fields are preserved. Calls to `GET /v1/jobs` without query parameters retain the existing unbounded behavior; new response fields are additive. Invalid bounds and unsupported work modes use the existing validation error envelope.

## Security and privacy

- tests use synthetic, manually authored records only
- raw job payloads remain internal and are not returned
- missing company, source, location, salary, and time fields remain null rather than inferred
- observation time is resolved from the linked raw record only
- no candidate data, credentials, screenshots, or external job-board records are included

## Screenshots

Not applicable: this pull request changes the API contract and contains no visible frontend changes.

## Known limitations

- the list response does not yet include total-count metadata
- unbounded requests remain supported for backward compatibility
- source filtering is exact and case-sensitive
- no new salary, location, seniority, or time-series aggregate is introduced
- the browser job explorer will be implemented only after this pull request is merged