### PR TITLE
feat: add job exploration interface

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -54,8 +54,8 @@ quality task.
 | --- | --- |
 | `/` | Product overview and developer access |
 | `/market` | API-backed market dashboard |
-| `/jobs` | Foundation placeholder for the job explorer |
+| `/jobs` | API-backed bounded job explorer with details |
 | `/match` | Foundation placeholder for candidate matching |
 
-The placeholder routes define navigation and page boundaries without claiming that later product
-features are implemented.
+The remaining placeholder route defines its navigation and page boundary without claiming that
+candidate matching is implemented.

--- a/frontend/src/api/jobs.ts
+++ b/frontend/src/api/jobs.ts
@@ -1,0 +1,67 @@
+import { requestJson } from './client'
+
+export type WorkMode = 'remote' | 'hybrid' | 'onsite' | 'unknown'
+
+export type JobSummary = {
+  job_id: number
+  title: string
+  source_name: string
+  work_mode: string
+  location_text: string | null
+  salary_text: string | null
+  company_name: string | null
+  source_url: string | null
+  posted_at: string | null
+  employment_type: string
+}
+
+export type JobLocation = {
+  country: string | null
+  region: string | null
+  city: string | null
+  raw_text: string | null
+}
+
+export type JobEnrichment = {
+  job_id: number | null
+  role_family: string | null
+  seniority: string | null
+  confidence: number | null
+  skills: string[]
+  technologies: string[]
+  summary: string | null
+}
+
+export type JobDetail = JobSummary & {
+  description: string
+  location: JobLocation
+  seniority_hint: string
+  observed_at: string | null
+  enrichment: JobEnrichment | null
+}
+
+export type JobListQuery = {
+  limit?: number
+  offset?: number
+  workMode?: WorkMode
+}
+
+export function listJobs(query: JobListQuery, signal?: AbortSignal) {
+  const search = new URLSearchParams()
+  if (query.limit !== undefined) {
+    search.set('limit', String(query.limit))
+  }
+  if (query.offset !== undefined) {
+    search.set('offset', String(query.offset))
+  }
+  if (query.workMode !== undefined) {
+    search.set('work_mode', query.workMode)
+  }
+
+  const queryString = search.size > 0 ? `?${search}` : ''
+  return requestJson<JobSummary[]>(`/v1/jobs${queryString}`, { signal })
+}
+
+export function getJob(jobId: number, signal?: AbortSignal) {
+  return requestJson<JobDetail>(`/v1/jobs/${jobId}`, { signal })
+}

--- a/frontend/src/api/market.ts
+++ b/frontend/src/api/market.ts
@@ -1,13 +1,7 @@
 import { requestJson } from './client'
+import { listJobs } from './jobs'
 
-export type JobSummary = {
-  job_id: number
-  title: string
-  source_name: string
-  work_mode: string
-  location_text: string | null
-  salary_text: string | null
-}
+export type { JobSummary } from './jobs'
 
 export type MetricBucket = {
   label: string
@@ -21,7 +15,7 @@ export type SkillCooccurrence = {
 }
 
 export function getJobs(signal?: AbortSignal) {
-  return requestJson<JobSummary[]>('/v1/jobs', { signal })
+  return listJobs({}, signal)
 }
 
 export function getTopSkills(signal?: AbortSignal) {

--- a/frontend/src/pages/JobExplorerPage.tsx
+++ b/frontend/src/pages/JobExplorerPage.tsx
@@ -1,12 +1,386 @@
-import { FeaturePlaceholder } from '../components/FeaturePlaceholder'
+import { useCallback, useState } from 'react'
+
+import {
+  getJob,
+  listJobs,
+  type JobDetail,
+  type JobSummary,
+  type WorkMode,
+} from '../api/jobs'
+import { PanelState } from '../components/PanelState'
+import { useApiResource } from '../hooks/useApiResource'
+
+const pageSize = 12
+const workModes: { value: WorkMode | ''; label: string }[] = [
+  { value: '', label: 'All work modes' },
+  { value: 'remote', label: 'Remote' },
+  { value: 'hybrid', label: 'Hybrid' },
+  { value: 'onsite', label: 'On-site' },
+  { value: 'unknown', label: 'Not specified' },
+]
+
+function formatLabel(value: string) {
+  return value
+    .replaceAll('_', ' ')
+    .replace(/\b\w/g, (character) => character.toUpperCase())
+}
+
+function displayValue(value: string | null | undefined) {
+  return value?.trim() || 'Not provided'
+}
+
+function displayEnum(value: string | null | undefined) {
+  return !value || value === 'unknown' ? 'Not provided' : formatLabel(value)
+}
+
+function formatDate(value: string | null) {
+  if (!value) {
+    return 'Not provided'
+  }
+
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return 'Not provided'
+  }
+
+  return new Intl.DateTimeFormat('en', {
+    dateStyle: 'medium',
+    timeZone: 'UTC',
+  }).format(date)
+}
+
+function safeSourceUrl(value: string | null) {
+  if (!value) {
+    return null
+  }
+
+  try {
+    const url = new URL(value)
+    return url.protocol === 'http:' || url.protocol === 'https:'
+      ? url.toString()
+      : null
+  } catch {
+    return null
+  }
+}
+
+function JobDetailPanel({
+  jobId,
+  onClose,
+}: {
+  jobId: number
+  onClose: () => void
+}) {
+  const load = useCallback(
+    (signal: AbortSignal) => getJob(jobId, signal),
+    [jobId],
+  )
+  const detail = useApiResource(load)
+
+  return (
+    <section
+      className="job-detail-shell"
+      id={`job-detail-${jobId}`}
+      aria-labelledby={`job-detail-title-${jobId}`}
+    >
+      <div className="job-detail-toolbar">
+        <p>Selected job details</p>
+        <button type="button" onClick={onClose}>
+          Close details
+        </button>
+      </div>
+      <PanelState
+        state={detail.state}
+        isEmpty={() => false}
+        emptyTitle="Job details are unavailable"
+        emptyMessage="No detail was returned for this job."
+        errorTitle="Job details could not be loaded"
+        onRetry={detail.retry}
+      >
+        {(job) => <JobDetailContent job={job} />}
+      </PanelState>
+    </section>
+  )
+}
+
+function JobDetailContent({ job }: { job: JobDetail }) {
+  const sourceUrl = safeSourceUrl(job.source_url)
+  const seniority =
+    job.enrichment?.seniority && job.enrichment.seniority !== 'unknown'
+      ? job.enrichment.seniority
+      : job.seniority_hint
+  const location =
+    job.location.raw_text ||
+    [job.location.city, job.location.region, job.location.country]
+      .filter(Boolean)
+      .join(', ')
+
+  return (
+    <article className="job-detail">
+      <header className="job-detail-header">
+        <div>
+          <p className="panel-kicker">{formatLabel(job.source_name)}</p>
+          <h2 id={`job-detail-title-${job.job_id}`}>{job.title}</h2>
+          <p>{displayValue(job.company_name)}</p>
+        </div>
+        <span className="job-mode">{displayEnum(job.work_mode)}</span>
+      </header>
+
+      <dl className="job-facts">
+        <div>
+          <dt>Location</dt>
+          <dd>{displayValue(location)}</dd>
+        </div>
+        <div>
+          <dt>Seniority</dt>
+          <dd>{displayEnum(seniority)}</dd>
+        </div>
+        <div>
+          <dt>Employment</dt>
+          <dd>{displayEnum(job.employment_type)}</dd>
+        </div>
+        <div>
+          <dt>Published</dt>
+          <dd>{formatDate(job.posted_at)}</dd>
+        </div>
+        <div>
+          <dt>Observed</dt>
+          <dd>{formatDate(job.observed_at)}</dd>
+        </div>
+        <div>
+          <dt>Source</dt>
+          <dd>
+            {sourceUrl ? (
+              <a href={sourceUrl} rel="noreferrer" target="_blank">
+                {formatLabel(job.source_name)}
+                <span className="visually-hidden"> (opens in a new tab)</span>
+              </a>
+            ) : (
+              formatLabel(job.source_name)
+            )}
+          </dd>
+        </div>
+      </dl>
+
+      {job.enrichment?.summary && (
+        <section className="job-detail-section">
+          <h3>Role summary</h3>
+          <p>{job.enrichment.summary}</p>
+        </section>
+      )}
+
+      <section className="job-detail-section">
+        <h3>Description</h3>
+        <p className="job-description">{job.description}</p>
+      </section>
+
+      <div className="job-taxonomy-grid">
+        <TaxonomyList
+          title="Skills"
+          items={job.enrichment?.skills ?? []}
+          emptyMessage="No skills detected"
+        />
+        <TaxonomyList
+          title="Technologies"
+          items={job.enrichment?.technologies ?? []}
+          emptyMessage="No technologies detected"
+        />
+      </div>
+    </article>
+  )
+}
+
+function TaxonomyList({
+  title,
+  items,
+  emptyMessage,
+}: {
+  title: string
+  items: string[]
+  emptyMessage: string
+}) {
+  return (
+    <section className="taxonomy-group">
+      <h3>{title}</h3>
+      {items.length > 0 ? (
+        <ul>
+          {items.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+      ) : (
+        <p>{emptyMessage}</p>
+      )}
+    </section>
+  )
+}
+
+function JobCard({
+  job,
+  selected,
+  onSelect,
+}: {
+  job: JobSummary
+  selected: boolean
+  onSelect: () => void
+}) {
+  return (
+    <article className={selected ? 'job-card job-card-selected' : 'job-card'}>
+      <div className="job-card-topline">
+        <span>{formatLabel(job.source_name)}</span>
+        <span>{displayEnum(job.work_mode)}</span>
+      </div>
+      <h2>{job.title}</h2>
+      <p className="job-company">{displayValue(job.company_name)}</p>
+      <dl className="job-card-facts">
+        <div>
+          <dt>Location</dt>
+          <dd>{displayValue(job.location_text)}</dd>
+        </div>
+        <div>
+          <dt>Employment</dt>
+          <dd>{displayEnum(job.employment_type)}</dd>
+        </div>
+      </dl>
+      <button
+        className="job-detail-button"
+        type="button"
+        aria-expanded={selected}
+        aria-controls={selected ? `job-detail-${job.job_id}` : undefined}
+        onClick={onSelect}
+      >
+        {selected ? 'Details selected' : 'View details'}
+        <span aria-hidden="true">→</span>
+      </button>
+    </article>
+  )
+}
 
 export function JobExplorerPage() {
+  const [offset, setOffset] = useState(0)
+  const [workMode, setWorkMode] = useState<WorkMode | ''>('')
+  const [selectedJobId, setSelectedJobId] = useState<number | null>(null)
+
+  const loadJobs = useCallback(
+    (signal: AbortSignal) =>
+      listJobs(
+        {
+          limit: pageSize + 1,
+          offset,
+          workMode: workMode || undefined,
+        },
+        signal,
+      ),
+    [offset, workMode],
+  )
+  const jobs = useApiResource(loadJobs)
+
+  function updateWorkMode(value: string) {
+    setWorkMode(value as WorkMode | '')
+    setOffset(0)
+    setSelectedJobId(null)
+  }
+
   return (
-    <FeaturePlaceholder
-      eyebrow="Job explorer"
-      title="Inspect the evidence behind the market."
-      description="Browse the available roles and their normalized skills, technologies, work mode, and source."
-      nextStep="Job browsing and detail views will be implemented after the required API provenance and pagination contracts are reviewed."
-    />
+    <div className="job-explorer page-stack">
+      <header className="page-header job-explorer-header">
+        <div>
+          <p className="eyebrow">Job explorer</p>
+          <h1>Inspect the roles behind the signals.</h1>
+          <p className="page-lead">
+            Browse bounded results, filter by supported work mode, and inspect
+            the available enrichment and source context.
+          </p>
+        </div>
+        <div className="explorer-filter">
+          <label htmlFor="work-mode-filter">Work mode</label>
+          <select
+            id="work-mode-filter"
+            value={workMode}
+            onChange={(event) => updateWorkMode(event.target.value)}
+          >
+            {workModes.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </header>
+
+      <PanelState
+        state={jobs.state}
+        isEmpty={(data) => data.length === 0}
+        emptyTitle={workMode ? 'No jobs match this work mode' : 'No jobs are stored yet'}
+        emptyMessage={
+          workMode
+            ? 'Choose another work mode or return to all available jobs.'
+            : 'Jobs will appear here after manually authored or authorized records are added.'
+        }
+        errorTitle="Jobs could not be loaded"
+        onRetry={jobs.retry}
+      >
+        {(data) => {
+          const visibleJobs = data.slice(0, pageSize)
+          const hasNextPage = data.length > pageSize
+          const pageNumber = Math.floor(offset / pageSize) + 1
+
+          return (
+            <>
+              <div className="explorer-results-heading">
+                <p>
+                  Page {pageNumber} · Showing {visibleJobs.length} job
+                  {visibleJobs.length === 1 ? '' : 's'}
+                </p>
+                <p>Missing source fields are shown as not provided.</p>
+              </div>
+
+              <div className="job-grid">
+                {visibleJobs.map((job) => (
+                  <JobCard
+                    job={job}
+                    selected={selectedJobId === job.job_id}
+                    onSelect={() => setSelectedJobId(job.job_id)}
+                    key={job.job_id}
+                  />
+                ))}
+              </div>
+
+              {selectedJobId !== null && (
+                <JobDetailPanel
+                  jobId={selectedJobId}
+                  onClose={() => setSelectedJobId(null)}
+                  key={selectedJobId}
+                />
+              )}
+
+              <nav className="pagination" aria-label="Job result pages">
+                <button
+                  type="button"
+                  disabled={offset === 0}
+                  onClick={() => {
+                    setOffset((current) => Math.max(0, current - pageSize))
+                    setSelectedJobId(null)
+                  }}
+                >
+                  Previous
+                </button>
+                <span>Page {pageNumber}</span>
+                <button
+                  type="button"
+                  disabled={!hasNextPage}
+                  onClick={() => {
+                    setOffset((current) => current + pageSize)
+                    setSelectedJobId(null)
+                  }}
+                >
+                  Next
+                </button>
+              </nav>
+            </>
+          )
+        }}
+      </PanelState>
+    </div>
   )
 }

--- a/frontend/src/pages/JobExplorerPage.tsx
+++ b/frontend/src/pages/JobExplorerPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import {
   getJob,
@@ -76,12 +76,22 @@ function JobDetailPanel({
     [jobId],
   )
   const detail = useApiResource(load)
+  const detailRef = useRef<HTMLElement>(null)
+
+  useEffect(() => {
+    if (detail.state.status === 'success') {
+      detailRef.current?.focus()
+    }
+  }, [detail.state.status])
 
   return (
     <section
       className="job-detail-shell"
       id={`job-detail-${jobId}`}
       aria-labelledby={`job-detail-title-${jobId}`}
+      aria-live="polite"
+      ref={detailRef}
+      tabIndex={-1}
     >
       <div className="job-detail-toolbar">
         <p>Selected job details</p>
@@ -249,7 +259,7 @@ function JobCard({
         aria-controls={selected ? `job-detail-${job.job_id}` : undefined}
         onClick={onSelect}
       >
-        {selected ? 'Details selected' : 'View details'}
+        {selected ? 'Hide details' : 'View details'}
         <span aria-hidden="true">→</span>
       </button>
     </article>
@@ -340,7 +350,11 @@ export function JobExplorerPage() {
                   <JobCard
                     job={job}
                     selected={selectedJobId === job.job_id}
-                    onSelect={() => setSelectedJobId(job.job_id)}
+                    onSelect={() =>
+                      setSelectedJobId((current) =>
+                        current === job.job_id ? null : job.job_id,
+                      )
+                    }
                     key={job.job_id}
                   />
                 ))}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -881,6 +881,316 @@ p {
   white-space: nowrap;
 }
 
+.job-explorer-header {
+  display: grid;
+  max-width: none;
+  grid-template-columns: minmax(0, 1fr) minmax(220px, 0.3fr);
+  align-items: end;
+  gap: 48px;
+}
+
+.explorer-filter {
+  display: grid;
+  gap: 8px;
+}
+
+.explorer-filter label {
+  color: var(--ink);
+  font-size: 0.75rem;
+  font-weight: 800;
+}
+
+.explorer-filter select {
+  width: 100%;
+  min-height: 46px;
+  padding: 9px 38px 9px 13px;
+  border: 1px solid #aebbb7;
+  border-radius: 8px;
+  color: var(--ink);
+  background: var(--paper);
+}
+
+.explorer-results-heading {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 20px;
+  gap: 24px;
+}
+
+.explorer-results-heading p {
+  margin: 0;
+  font-size: 0.78rem;
+}
+
+.job-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.job-card {
+  display: flex;
+  min-height: 310px;
+  padding: 24px;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  flex-direction: column;
+  background: rgb(255 254 250 / 85%);
+  transition:
+    border-color 150ms ease,
+    transform 150ms ease,
+    box-shadow 150ms ease;
+}
+
+.job-card:hover {
+  border-color: #9dafaa;
+  transform: translateY(-2px);
+  box-shadow: 0 18px 40px rgb(24 47 61 / 8%);
+}
+
+.job-card-selected {
+  border-color: var(--teal);
+  box-shadow: 0 0 0 2px rgb(8 127 115 / 12%);
+}
+
+.job-card-topline {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 28px;
+  gap: 14px;
+}
+
+.job-card-topline span {
+  color: var(--teal-dark);
+  font-size: 0.66rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.job-card-topline span:last-child {
+  color: var(--muted);
+}
+
+.job-card h2 {
+  margin-bottom: 8px;
+  font-size: 1.24rem;
+  letter-spacing: -0.025em;
+}
+
+.job-company {
+  margin: 0 0 24px;
+  font-size: 0.82rem;
+}
+
+.job-card-facts {
+  display: grid;
+  margin: auto 0 22px;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+
+.job-card-facts dt,
+.job-facts dt {
+  margin-bottom: 5px;
+  color: var(--muted);
+  font-size: 0.64rem;
+  font-weight: 750;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.job-card-facts dd,
+.job-facts dd {
+  margin: 0;
+  color: var(--ink);
+  font-size: 0.76rem;
+  line-height: 1.45;
+}
+
+.job-detail-button {
+  display: flex;
+  width: 100%;
+  padding: 11px 0 0;
+  border: 0;
+  border-top: 1px solid var(--line);
+  align-items: center;
+  justify-content: space-between;
+  color: var(--teal-dark);
+  background: transparent;
+  font-size: 0.78rem;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.job-detail-shell {
+  margin-top: 24px;
+  padding: clamp(22px, 4vw, 38px);
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  background: var(--paper);
+  box-shadow: var(--shadow);
+}
+
+.job-detail-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-bottom: 18px;
+  border-bottom: 1px solid var(--line);
+  margin-bottom: 28px;
+  gap: 20px;
+}
+
+.job-detail-toolbar p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 750;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.job-detail-toolbar button {
+  padding: 7px 10px;
+  border: 1px solid #b9c3c0;
+  border-radius: 7px;
+  color: var(--ink);
+  background: white;
+  font-size: 0.74rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.job-detail-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 30px;
+  gap: 30px;
+}
+
+.job-detail-header h2 {
+  margin-bottom: 8px;
+}
+
+.job-detail-header p {
+  margin: 0;
+}
+
+.job-mode {
+  padding: 7px 11px;
+  border-radius: 999px;
+  color: var(--teal-dark);
+  background: var(--teal-soft);
+  font-size: 0.7rem;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.job-facts {
+  display: grid;
+  padding: 20px;
+  border: 1px solid var(--line);
+  border-radius: 11px;
+  margin: 0 0 30px;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 22px;
+  background: #f8f8f4;
+}
+
+.job-facts a {
+  color: var(--teal-dark);
+  text-underline-offset: 3px;
+}
+
+.job-detail-section {
+  max-width: 850px;
+  margin-bottom: 30px;
+}
+
+.job-detail-section h3,
+.taxonomy-group h3 {
+  margin-bottom: 9px;
+  font-size: 0.8rem;
+  letter-spacing: 0.01em;
+}
+
+.job-detail-section p {
+  margin: 0;
+}
+
+.job-description {
+  white-space: pre-wrap;
+}
+
+.job-taxonomy-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+}
+
+.taxonomy-group {
+  padding: 20px;
+  border: 1px solid var(--line);
+  border-radius: 11px;
+}
+
+.taxonomy-group ul {
+  display: flex;
+  margin: 0;
+  padding: 0;
+  flex-wrap: wrap;
+  gap: 8px;
+  list-style: none;
+}
+
+.taxonomy-group li {
+  padding: 6px 9px;
+  border-radius: 999px;
+  color: var(--teal-dark);
+  background: var(--teal-soft);
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: capitalize;
+}
+
+.taxonomy-group p {
+  margin: 0;
+  font-size: 0.78rem;
+}
+
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 32px;
+  gap: 20px;
+}
+
+.pagination button {
+  min-width: 92px;
+  padding: 9px 13px;
+  border: 1px solid #aebbb7;
+  border-radius: 7px;
+  color: var(--ink);
+  background: var(--paper);
+  font-size: 0.76rem;
+  font-weight: 750;
+  cursor: pointer;
+}
+
+.pagination button:disabled {
+  color: #929d99;
+  background: #eceeeb;
+  cursor: not-allowed;
+}
+
+.pagination span {
+  color: var(--muted);
+  font-size: 0.76rem;
+}
+
 .not-found {
   max-width: 720px;
   padding-block: 80px;
@@ -956,7 +1266,8 @@ p {
   .placeholder-card,
   .dashboard-header,
   .summary-grid,
-  .dashboard-grid {
+  .dashboard-grid,
+  .job-explorer-header {
     grid-template-columns: 1fr;
   }
 
@@ -998,6 +1309,10 @@ p {
 
   .panel-heading > p {
     text-align: left;
+  }
+
+  .job-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
@@ -1057,6 +1372,18 @@ p {
 
   .placeholder-card > div:last-child {
     padding: 28px;
+  }
+
+  .explorer-results-heading,
+  .job-detail-header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .job-grid,
+  .job-facts,
+  .job-taxonomy-grid {
+    grid-template-columns: 1fr;
   }
 
   .footer-inner {


### PR DESCRIPTION
## Purpose

Make stored jobs understandable and explorable in the browser without requiring direct API knowledge or inventing unavailable source fields.

## Changes

- replace the jobs placeholder with an API-backed explorer
- request 12 visible jobs plus one look-ahead record for bounded Next/Previous navigation
- add a controlled filter for the API-supported work-mode values
- display title, company, location, employment type, work mode, and source when available
- fetch enriched job details on demand
- show description, structured location, seniority, publication and observation dates, source provenance, skills, and technologies
- restrict external source links to HTTP and HTTPS URLs
- render missing and `unknown` values as “Not provided”
- include loading, empty, list failure, detail failure, retry, and not-found behavior
- add responsive and keyboard-visible styling
- document the implemented frontend route

## Validation

- `npm ci`
- `npm audit` — 0 vulnerabilities
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- synthetic integration checks covered the route, look-ahead pagination, second page, work-mode filter, enriched detail, missing fields, and 404 response
- staged diff and whitespace checks passed
- sensitive-file, likely-secret, credential, personal-path, and email checks passed

## Security and privacy

- no job or candidate records are bundled
- integration validation used manually authored synthetic jobs only
- API text is rendered as text rather than injected markup
- source links reject non-HTTP(S) protocols
- missing fields are not inferred
- no free-text source filter exposes raw or unexpected source categories

## Screenshots

No screenshot artifact is included in this pull request.

## Known limitations

- pagination cannot show a total page count because the API has no total-count metadata
- filtering is limited to work mode; source filtering is deferred until known source values are exposed cleanly
- the explorer displays at most 12 jobs per page
- the backend must be running for populated results
- frontend component tests remain scheduled for the dedicated quality pull request
- candidate matching is not changed in this pull request
- this pull request must be merged before candidate matching UI work begins