### PR TITLE
feat: validate candidate matching input

### DIFF
--- a/docs/07-api-examples.md
+++ b/docs/07-api-examples.md
@@ -101,6 +101,9 @@ Candidate profiles use bounded structured input:
 - optional location: 1 to 255 characters
 - optional years of experience: 0 to 80
 
+Skill names are deduplicated case-insensitively after trimming. When duplicates provide different
+proficiency values, the first entry is retained.
+
 The endpoint does not accept CV files or require names, email addresses, or contact details.
 
 ## Expected Response Characteristics

--- a/docs/07-api-examples.md
+++ b/docs/07-api-examples.md
@@ -93,6 +93,16 @@ curl -X POST http://localhost:8000/v1/candidates/matches \
   }'
 ```
 
+Candidate profiles use bounded structured input:
+
+- summary: 10 to 2,000 characters after trimming
+- skills: 1 to 50 entries, each with a 1 to 100 character name
+- optional proficiency: 1 to 50 characters
+- optional location: 1 to 255 characters
+- optional years of experience: 0 to 80
+
+The endpoint does not accept CV files or require names, email addresses, or contact details.
+
 ## Expected Response Characteristics
 
 Job enrichment responses include:

--- a/src/job_market/interfaces/schemas/candidates.py
+++ b/src/job_market/interfaces/schemas/candidates.py
@@ -2,16 +2,35 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel
+from typing import Annotated
+
+from pydantic import BaseModel, Field, StringConstraints
+
+CandidateSummary = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, min_length=10, max_length=2000),
+]
+CandidateSkillName = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, min_length=1, max_length=100),
+]
+SkillProficiency = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, min_length=1, max_length=50),
+]
+CandidateLocation = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, min_length=1, max_length=255),
+]
 
 
 class CandidateSkillInput(BaseModel):
-    name: str
-    proficiency: str | None = None
+    name: CandidateSkillName
+    proficiency: SkillProficiency | None = None
 
 
 class CandidateProfileRequest(BaseModel):
-    summary: str
-    skills: list[CandidateSkillInput]
-    location: str | None = None
-    years_experience: float | None = None
+    summary: CandidateSummary
+    skills: list[CandidateSkillInput] = Field(..., min_length=1, max_length=50)
+    location: CandidateLocation | None = None
+    years_experience: float | None = Field(default=None, ge=0, le=80)

--- a/src/job_market/interfaces/schemas/candidates.py
+++ b/src/job_market/interfaces/schemas/candidates.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from pydantic import BaseModel, Field, StringConstraints
+from pydantic import BaseModel, Field, StringConstraints, field_validator
 
 CandidateSummary = Annotated[
     str,
@@ -34,3 +34,18 @@ class CandidateProfileRequest(BaseModel):
     skills: list[CandidateSkillInput] = Field(..., min_length=1, max_length=50)
     location: CandidateLocation | None = None
     years_experience: float | None = Field(default=None, ge=0, le=80)
+
+    @field_validator("skills")
+    @classmethod
+    def deduplicate_skills(
+        cls,
+        skills: list[CandidateSkillInput],
+    ) -> list[CandidateSkillInput]:
+        unique_skills: list[CandidateSkillInput] = []
+        seen_names: set[str] = set()
+        for skill in skills:
+            normalized_name = skill.name.casefold()
+            if normalized_name not in seen_names:
+                seen_names.add(normalized_name)
+                unique_skills.append(skill)
+        return unique_skills

--- a/tests/api/test_api_routes.py
+++ b/tests/api/test_api_routes.py
@@ -164,3 +164,61 @@ def test_candidate_matches_endpoint(client: TestClient) -> None:
     assert len(body) == 1
     assert body[0]["match_score"] == pytest.approx(0.55)
     assert any(reason["type"] == "technology_alignment" for reason in body[0]["reasons"])
+
+
+@pytest.mark.parametrize(
+    ("candidate_overrides", "field"),
+    [
+        ({"summary": "   "}, "summary"),
+        ({"summary": "Too short"}, "summary"),
+        ({"summary": "x" * 2001}, "summary"),
+        ({"skills": []}, "skills"),
+        ({"skills": [{"name": "python"}] * 51}, "skills"),
+        ({"skills": [{"name": "   "}]}, "name"),
+        ({"skills": [{"name": "x" * 101}]}, "name"),
+        ({"skills": [{"name": "python", "proficiency": "x" * 51}]}, "proficiency"),
+        ({"location": "x" * 256}, "location"),
+        ({"years_experience": -1}, "years_experience"),
+        ({"years_experience": 81}, "years_experience"),
+    ],
+)
+def test_candidate_matches_rejects_invalid_profile_fields(
+    client: TestClient,
+    candidate_overrides: dict[str, object],
+    field: str,
+) -> None:
+    candidate = {
+        "summary": "Synthetic engineer profile.",
+        "skills": [{"name": "python"}],
+        **candidate_overrides,
+    }
+
+    response = client.post("/v1/candidates/matches", json=candidate)
+
+    assert response.status_code == 422
+    assert response.json()["error"] == "validation_error"
+    assert any(field in error["loc"] for error in response.json()["details"])
+
+
+def test_candidate_matches_trims_profile_text(client: TestClient) -> None:
+    client.post(
+        "/v1/jobs:upload",
+        json={
+            "title": "Synthetic Backend Engineer",
+            "description": "Python required.",
+            "source_name": "manual_upload",
+        },
+    )
+
+    response = client.post(
+        "/v1/candidates/matches",
+        json={
+            "summary": "  Synthetic Python engineer.  ",
+            "skills": [{"name": "  python  ", "proficiency": "  advanced  "}],
+            "location": "  Remote  ",
+            "years_experience": 4,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()[0]["matching_skills"] == ["python"]

--- a/tests/unit/test_candidate_schemas.py
+++ b/tests/unit/test_candidate_schemas.py
@@ -1,0 +1,17 @@
+from job_market.interfaces.schemas.candidates import CandidateProfileRequest
+
+
+def test_candidate_profile_deduplicates_trimmed_skill_names_case_insensitively() -> None:
+    profile = CandidateProfileRequest.model_validate(
+        {
+            "summary": "Synthetic software engineer.",
+            "skills": [
+                {"name": " Python ", "proficiency": " advanced "},
+                {"name": "python", "proficiency": "beginner"},
+                {"name": "SQL"},
+            ],
+        }
+    )
+
+    assert [skill.name for skill in profile.skills] == ["Python", "SQL"]
+    assert profile.skills[0].proficiency == "advanced"


### PR DESCRIPTION
## Purpose

Define a bounded, privacy-conscious candidate input contract before exposing matching through the browser.

## Changes

- trim candidate summary, skill name, proficiency, and location text
- require a 10–2,000 character summary
- require 1–50 skills with 1–100 character names
- bound optional proficiency to 1–50 characters
- bound optional location to 1–255 characters
- constrain optional years of experience to 0–80
- preserve the existing request shape and validation error envelope
- add synthetic API tests for every boundary and trimming behavior
- document the candidate input limits and no-CV/no-contact-data scope

## Validation

- `ruff check .`
- `ruff format --check .`
- `mypy`
- `pytest` — 30 passed
- `python -m compileall src apps tests alembic`
- staged diff and whitespace checks passed
- sensitive-file, likely-secret, credential, personal-path, and email checks passed

## Security and privacy

- no candidate records or real personal data are included
- tests use synthetic profile text only
- the contract does not request names, email addresses, contact details, or CV files
- input sizes are bounded before matching and persistence

## Screenshots

Not applicable: this pull request changes the API validation contract and contains no visible frontend changes.

## Known limitations

- skill names remain free-form and are not restricted to the enrichment taxonomy
- duplicate skill names are not rejected or deduplicated at the schema boundary
- proficiency remains descriptive text and does not affect the current scorer
- location and years of experience do not affect the current deterministic score
- the browser matching interface will begin only after this pull request is merged