### PR TITLE
feat: add candidate matching interface

### DIFF
--- a/frontend/src/api/candidates.ts
+++ b/frontend/src/api/candidates.ts
@@ -1,0 +1,42 @@
+import { requestJson } from './client'
+
+export type CandidateSkillInput = {
+  name: string
+  proficiency?: string
+}
+
+export type CandidateProfile = {
+  summary: string
+  skills: CandidateSkillInput[]
+  location?: string
+  years_experience?: number
+}
+
+export type MatchReason = {
+  type: string
+  message: string
+}
+
+export type MatchResult = {
+  match_id: number | null
+  job_id: number | null
+  job_title: string
+  source_name: string
+  match_score: number
+  matching_skills: string[]
+  missing_skills: string[]
+  confidence: number
+  reasons: MatchReason[]
+}
+
+export function matchCandidate(
+  profile: CandidateProfile,
+  signal?: AbortSignal,
+): Promise<MatchResult[]> {
+  return requestJson<MatchResult[]>('/v1/candidates/matches', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(profile),
+    signal,
+  })
+}

--- a/frontend/src/pages/CandidateMatchingPage.tsx
+++ b/frontend/src/pages/CandidateMatchingPage.tsx
@@ -1,12 +1,301 @@
-import { FeaturePlaceholder } from '../components/FeaturePlaceholder'
+import {
+  type FormEvent,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
+
+import {
+  matchCandidate,
+  type CandidateProfile,
+  type MatchResult,
+} from '../api/candidates'
+import { EmptyState, ErrorState, LoadingState } from '../components/AsyncState'
+
+type SkillRow = { id: number; name: string; proficiency: string }
+type FormErrors = { summary?: string; skills?: string; years?: string }
+type ResultState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'success'; data: MatchResult[] }
+  | { status: 'error'; message: string }
+
+const initialSkill: SkillRow = { id: 1, name: '', proficiency: '' }
+
+function percentage(value: number) {
+  return `${Math.round(Math.max(0, Math.min(1, value)) * 100)}%`
+}
+
+function validate(
+  summary: string,
+  skills: SkillRow[],
+  years: string,
+): FormErrors {
+  const errors: FormErrors = {}
+  const trimmedSummary = summary.trim()
+  const namedSkills = skills.filter((skill) => skill.name.trim())
+
+  if (trimmedSummary.length < 10) {
+    errors.summary = 'Enter at least 10 characters.'
+  } else if (trimmedSummary.length > 2000) {
+    errors.summary = 'Keep the summary within 2,000 characters.'
+  }
+
+  if (namedSkills.length === 0) {
+    errors.skills = 'Add at least one skill.'
+  } else if (
+    new Set(namedSkills.map((skill) => skill.name.trim().toLocaleLowerCase()))
+      .size !== namedSkills.length
+  ) {
+    errors.skills = 'Remove duplicate skills.'
+  } else if (
+    namedSkills.some(
+      (skill) =>
+        skill.name.trim().length > 100 ||
+        skill.proficiency.trim().length > 50,
+    )
+  ) {
+    errors.skills = 'Keep skill names within 100 characters and levels within 50.'
+  }
+
+  const numericYears = Number(years)
+  if (
+    years.trim() &&
+    (!Number.isFinite(numericYears) || numericYears < 0 || numericYears > 80)
+  ) {
+    errors.years = 'Enter a value from 0 to 80.'
+  }
+
+  return errors
+}
+
+function SkillList({ title, items }: { title: string; items: string[] }) {
+  return (
+    <section className="match-skills">
+      <h3>{title}</h3>
+      {items.length > 0 ? (
+        <ul>
+          {items.map((item) => <li key={item}>{item}</li>)}
+        </ul>
+      ) : (
+        <p>None reported</p>
+      )}
+    </section>
+  )
+}
+
+function MatchCard({ match, rank }: { match: MatchResult; rank: number }) {
+  return (
+    <article className="match-card">
+      <header>
+        <div>
+          <p className="panel-kicker">Rank {rank} · {match.source_name}</p>
+          <h2>{match.job_title}</h2>
+        </div>
+        <div className="match-score" aria-label={`Match score ${percentage(match.match_score)}`}>
+          <strong>{percentage(match.match_score)}</strong>
+          <span>match</span>
+        </div>
+      </header>
+      <p className="match-confidence">
+        Confidence: <strong>{percentage(match.confidence)}</strong>
+      </p>
+      <div className="match-skill-grid">
+        <SkillList title="Matched skills" items={match.matching_skills} />
+        <SkillList title="Missing skills" items={match.missing_skills} />
+      </div>
+      {match.reasons.length > 0 && (
+        <section className="match-reasons">
+          <h3>Why this result</h3>
+          <ul>
+            {match.reasons.map((reason, index) => (
+              <li key={`${reason.type}-${index}`}>{reason.message}</li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </article>
+  )
+}
 
 export function CandidateMatchingPage() {
+  const [summary, setSummary] = useState('')
+  const [location, setLocation] = useState('')
+  const [years, setYears] = useState('')
+  const [skills, setSkills] = useState<SkillRow[]>([initialSkill])
+  const [nextSkillId, setNextSkillId] = useState(2)
+  const [errors, setErrors] = useState<FormErrors>({})
+  const [result, setResult] = useState<ResultState>({ status: 'idle' })
+  const controllerRef = useRef<AbortController | null>(null)
+  const resultsRef = useRef<HTMLElement>(null)
+
+  useEffect(() => () => controllerRef.current?.abort(), [])
+  useEffect(() => {
+    if (result.status === 'success') resultsRef.current?.focus()
+  }, [result.status])
+
+  function updateSkill(id: number, field: 'name' | 'proficiency', value: string) {
+    setSkills((current) =>
+      current.map((skill) =>
+        skill.id === id
+          ? {
+              id: skill.id,
+              name: field === 'name' ? value : skill.name,
+              proficiency:
+                field === 'proficiency' ? value : skill.proficiency,
+            }
+          : skill,
+      ),
+    )
+  }
+
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const nextErrors = validate(summary, skills, years)
+    setErrors(nextErrors)
+    if (Object.keys(nextErrors).length > 0) return
+
+    const profile: CandidateProfile = {
+      summary: summary.trim(),
+      skills: skills
+        .filter((skill) => skill.name.trim())
+        .map((skill) => ({
+          name: skill.name.trim(),
+          proficiency: skill.proficiency.trim() || undefined,
+        })),
+      ...(location.trim() ? { location: location.trim() } : {}),
+      ...(years.trim() ? { years_experience: Number(years) } : {}),
+    }
+
+    controllerRef.current?.abort()
+    const controller = new AbortController()
+    controllerRef.current = controller
+    setResult({ status: 'loading' })
+    try {
+      const data = await matchCandidate(profile, controller.signal)
+      if (!controller.signal.aborted) setResult({ status: 'success', data })
+    } catch {
+      if (!controller.signal.aborted) {
+        setResult({
+          status: 'error',
+          message: 'Check that the API is available, then try again.',
+        })
+      }
+    }
+  }
+
   return (
-    <FeaturePlaceholder
-      eyebrow="Candidate matching"
-      title="Understand alignment, not just a score."
-      description="A structured, privacy-conscious workflow for comparing skills with jobs stored in this instance."
-      nextStep="A later pull request will add the validated candidate form and explainable ranked results. No CV upload or personal account is planned for this phase."
-    />
+    <div className="matching-page page-stack">
+      <header className="page-header matching-header">
+        <div>
+          <p className="eyebrow">Candidate matching</p>
+          <h1>Compare a skill profile with stored roles.</h1>
+          <p className="page-lead">
+            Get explainable, deterministic rankings based on the jobs available
+            in this instance—not a hiring decision or assessment.
+          </p>
+        </div>
+        <aside className="privacy-note">
+          <strong>Keep it anonymous</strong>
+          <p>Do not enter names, email addresses, contact details, or other personal information.</p>
+        </aside>
+      </header>
+
+      <div className="matching-layout">
+        <form className="candidate-form" onSubmit={submit} noValidate>
+          <div className="form-heading">
+            <h2>Candidate profile</h2>
+            <p>Fields marked required are used by the current matching model.</p>
+          </div>
+          <div className="field">
+            <label htmlFor="candidate-summary">Professional summary <span>Required</span></label>
+            <textarea
+              id="candidate-summary"
+              value={summary}
+              maxLength={2000}
+              aria-invalid={Boolean(errors.summary)}
+              aria-describedby={errors.summary ? 'summary-error' : 'summary-help'}
+              onChange={(event) => setSummary(event.target.value)}
+              rows={5}
+            />
+            <p id="summary-help" className="field-help">Describe relevant experience without identifying details.</p>
+            {errors.summary && <p id="summary-error" className="field-error">{errors.summary}</p>}
+          </div>
+
+          <fieldset className="skill-fieldset" aria-describedby={errors.skills ? 'skills-error' : undefined}>
+            <legend>Skills <span>Required</span></legend>
+            {skills.map((skill, index) => (
+              <div className="skill-row" key={skill.id}>
+                <div className="field">
+                  <label htmlFor={`skill-${skill.id}`}>Skill {index + 1}</label>
+                  <input
+                    id={`skill-${skill.id}`}
+                    value={skill.name}
+                    maxLength={100}
+                    onChange={(event) => updateSkill(skill.id, 'name', event.target.value)}
+                  />
+                </div>
+                <div className="field">
+                  <label htmlFor={`proficiency-${skill.id}`}>Level <span>Optional</span></label>
+                  <input
+                    id={`proficiency-${skill.id}`}
+                    value={skill.proficiency}
+                    maxLength={50}
+                    placeholder="e.g. advanced"
+                    onChange={(event) => updateSkill(skill.id, 'proficiency', event.target.value)}
+                  />
+                </div>
+                {skills.length > 1 && (
+                  <button type="button" className="remove-skill" onClick={() => setSkills((current) => current.filter((item) => item.id !== skill.id))}>
+                    Remove <span className="visually-hidden">skill {index + 1}</span>
+                  </button>
+                )}
+              </div>
+            ))}
+            {errors.skills && <p id="skills-error" className="field-error">{errors.skills}</p>}
+            <button
+              type="button"
+              className="add-skill"
+              disabled={skills.length >= 50}
+              onClick={() => {
+                setSkills((current) => [...current, { id: nextSkillId, name: '', proficiency: '' }])
+                setNextSkillId((current) => current + 1)
+              }}
+            >
+              + Add another skill
+            </button>
+          </fieldset>
+
+          <div className="optional-fields">
+            <div className="field">
+              <label htmlFor="candidate-location">Location <span>Optional</span></label>
+              <input id="candidate-location" value={location} maxLength={255} onChange={(event) => setLocation(event.target.value)} />
+            </div>
+            <div className="field">
+              <label htmlFor="candidate-years">Years of experience <span>Optional</span></label>
+              <input id="candidate-years" type="number" min="0" max="80" step="0.5" value={years} aria-invalid={Boolean(errors.years)} aria-describedby={errors.years ? 'years-error' : undefined} onChange={(event) => setYears(event.target.value)} />
+              {errors.years && <p id="years-error" className="field-error">{errors.years}</p>}
+            </div>
+          </div>
+          <button className="button button-primary match-submit" type="submit" disabled={result.status === 'loading'}>
+            {result.status === 'loading' ? 'Calculating matches…' : 'Find matching jobs'}
+          </button>
+        </form>
+
+        <section className="matching-results" aria-live="polite" aria-labelledby="matching-results-title" ref={resultsRef} tabIndex={-1}>
+          <h2 id="matching-results-title">Ranked results</h2>
+          {result.status === 'idle' && <EmptyState title="Ready when you are" message="Complete the profile to compare it with currently stored jobs." />}
+          {result.status === 'loading' && <LoadingState message="Comparing this profile with stored jobs." />}
+          {result.status === 'error' && <ErrorState title="Matches could not be calculated" message={result.message} />}
+          {result.status === 'success' && result.data.length === 0 && <EmptyState title="No matching jobs found" message="The API returned no ranked roles for this profile and current dataset." />}
+          {result.status === 'success' && result.data.length > 0 && (
+            <div className="match-list">
+              <p className="result-count">{result.data.length} ranked {result.data.length === 1 ? 'job' : 'jobs'}</p>
+              {result.data.map((match, index) => <MatchCard match={match} rank={index + 1} key={match.match_id ?? `${match.job_id}-${index}`} />)}
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
   )
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -40,8 +40,243 @@ body {
 body,
 button,
 input,
+select,
 textarea {
   font: inherit;
+}
+
+.matching-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 330px;
+  align-items: end;
+  gap: 48px;
+}
+
+.privacy-note {
+  padding: 22px;
+  border: 1px solid #ded4b8;
+  border-radius: 12px;
+  background: var(--warning);
+}
+
+.privacy-note strong {
+  color: var(--ink);
+}
+
+.privacy-note p {
+  margin: 6px 0 0;
+  color: #594c2e;
+  font-size: 0.82rem;
+}
+
+.matching-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 0.9fr) minmax(360px, 1.1fr);
+  align-items: start;
+  gap: 28px;
+}
+
+.candidate-form,
+.matching-results {
+  padding: clamp(24px, 4vw, 36px);
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  background: var(--paper);
+  box-shadow: var(--shadow);
+}
+
+.form-heading p,
+.field-help {
+  margin: 0;
+  font-size: 0.78rem;
+}
+
+.field {
+  display: grid;
+  gap: 7px;
+}
+
+.field > label,
+.skill-fieldset legend {
+  color: var(--ink);
+  font-size: 0.8rem;
+  font-weight: 750;
+}
+
+.field label span,
+.skill-fieldset legend span {
+  color: var(--muted);
+  font-size: 0.68rem;
+  font-weight: 600;
+}
+
+.field input,
+.field textarea {
+  width: 100%;
+  padding: 11px 12px;
+  border: 1px solid #aebbb7;
+  border-radius: 7px;
+  color: var(--ink);
+  background: white;
+}
+
+.field textarea {
+  resize: vertical;
+}
+
+.candidate-form > .field,
+.skill-fieldset,
+.optional-fields {
+  margin-top: 24px;
+}
+
+.skill-fieldset {
+  padding: 0;
+  border: 0;
+}
+
+.skill-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(120px, 0.8fr) auto;
+  align-items: end;
+  margin-top: 12px;
+  gap: 10px;
+}
+
+.add-skill,
+.remove-skill {
+  border: 0;
+  color: var(--teal-dark);
+  background: transparent;
+  font-size: 0.75rem;
+  font-weight: 750;
+  cursor: pointer;
+}
+
+.add-skill {
+  margin-top: 14px;
+  padding: 7px 0;
+}
+
+.remove-skill {
+  min-height: 42px;
+  padding-inline: 7px;
+  color: var(--danger);
+}
+
+.optional-fields,
+.match-skill-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.field-error {
+  margin: 0;
+  color: var(--danger);
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.match-submit {
+  width: 100%;
+  margin-top: 28px;
+  border: 0;
+  cursor: pointer;
+}
+
+.match-submit:disabled {
+  opacity: 0.7;
+  cursor: wait;
+}
+
+.matching-results > h2 {
+  margin-bottom: 24px;
+}
+
+.matching-results:focus {
+  outline: none;
+}
+
+.result-count {
+  margin: 0 0 12px;
+  font-size: 0.78rem;
+}
+
+.match-list {
+  display: grid;
+  gap: 16px;
+}
+
+.match-card {
+  padding: 22px;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: #fbfcf9;
+}
+
+.match-card header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.match-card h2 {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.match-score {
+  display: grid;
+  min-width: 68px;
+  text-align: right;
+}
+
+.match-score strong {
+  color: var(--teal-dark);
+  font-size: 1.4rem;
+}
+
+.match-score span {
+  color: var(--muted);
+  font-size: 0.68rem;
+  text-transform: uppercase;
+}
+
+.match-confidence {
+  margin: 14px 0;
+  font-size: 0.78rem;
+}
+
+.match-skills {
+  padding: 14px;
+  border-radius: 8px;
+  background: #eef3f0;
+}
+
+.match-skills h3,
+.match-reasons h3 {
+  margin-bottom: 8px;
+  font-size: 0.82rem;
+}
+
+.match-skills ul,
+.match-reasons ul {
+  margin: 0;
+  padding-left: 18px;
+  color: var(--muted);
+  font-size: 0.76rem;
+  line-height: 1.6;
+}
+
+.match-skills p {
+  margin: 0;
+  font-size: 0.75rem;
+}
+
+.match-reasons {
+  margin-top: 16px;
 }
 
 a {
@@ -1267,7 +1502,9 @@ p {
   .dashboard-header,
   .summary-grid,
   .dashboard-grid,
-  .job-explorer-header {
+  .job-explorer-header,
+  .matching-header,
+  .matching-layout {
     grid-template-columns: 1fr;
   }
 
@@ -1313,6 +1550,15 @@ p {
 
   .job-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .skill-row {
+    grid-template-columns: minmax(0, 1fr) minmax(120px, 0.7fr);
+  }
+
+  .remove-skill {
+    grid-column: 1 / -1;
+    justify-self: start;
   }
 }
 
@@ -1382,7 +1628,10 @@ p {
 
   .job-grid,
   .job-facts,
-  .job-taxonomy-grid {
+  .job-taxonomy-grid,
+  .optional-fields,
+  .match-skill-grid,
+  .skill-row {
     grid-template-columns: 1fr;
   }
 


### PR DESCRIPTION
## Purpose
Provide a privacy-conscious browser workflow for comparing a structured candidate profile with jobs stored in the platform.

## Changes
- add a typed candidate matching API client
- replace the placeholder with an accessible profile form aligned to the API contract
- validate summary, skills, duplicates, proficiency lengths, and experience range before submission
- display ranked scores, confidence, matched and missing skills, and backend-provided reasons
- cover idle, loading, empty, failure, and stale-request states
- add responsive styling and an explicit anonymous-data notice

## Validation
- `npm ci`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- changed-file, sensitive-file, secret-pattern, and personal-path review

## Security and privacy
The interface does not upload CVs, create accounts, or request identity/contact details. It explicitly asks users to keep profiles anonymous. No secrets, private records, or production data are included.

## Screenshots
No screenshot artifact is included in this incremental PR; safe product screenshots are reserved for the final public-presentation PR.

## Known limitations
- rankings depend entirely on jobs already stored in the instance
- matching is deterministic and should not be treated as a hiring decision
- component and end-to-end coverage will be added in the dedicated frontend quality PR